### PR TITLE
Fix cards database so new cards default to 'visible'

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,7 @@ gem 'rails_12factor', group: :production
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem 'rails', '4.2.5.1'
 # Use postgresql as the database for Active Record
-gem 'pg', '~> 0.18.2'
+gem 'pg', '~> 0.18.4'
 # Use SCSS for stylesheets
 gem 'sass-rails', '~> 5.0'
 # Use Uglifier as compressor for JavaScript assets

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -93,6 +93,7 @@ GEM
       cocaine (~> 0.5.5)
       mime-types
       mimemagic (= 0.3.0)
+    pg (0.18.4)
     pg (0.18.4-x86-mingw32)
     rack (1.6.4)
     rack-test (0.6.3)
@@ -177,7 +178,7 @@ DEPENDENCIES
   jbuilder (~> 2.0)
   jquery-rails
   paperclip
-  pg (~> 0.18.2)
+  pg (~> 0.18.4)
   rails (= 4.2.5.1)
   rails_12factor
   responders (~> 2.0)

--- a/db/migrate/20160206041454_update_visible_to_default_to_true.rb
+++ b/db/migrate/20160206041454_update_visible_to_default_to_true.rb
@@ -1,0 +1,5 @@
+class UpdateVisibleToDefaultToTrue < ActiveRecord::Migration
+  def change
+    change_column_default(:cards, :visible, true)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,15 +11,15 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160203002507) do
+ActiveRecord::Schema.define(version: 20160206041454) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
   create_table "cards", force: :cascade do |t|
-    t.boolean  "visible"
-    t.datetime "created_at",       null: false
-    t.datetime "updated_at",       null: false
+    t.boolean  "visible",          default: true
+    t.datetime "created_at",                      null: false
+    t.datetime "updated_at",                      null: false
     t.integer  "deck_id"
     t.string   "name"
     t.string   "question_text"


### PR DESCRIPTION
Created new migration to see field 'visible' to default to 'true'; updated Gemfile to update version on pg to 0.8.4 since 0.8.2 not existing in repositories
