### PR TITLE
Add migration to fix Delete Category bug

### DIFF
--- a/app/controllers/categories_controller.rb
+++ b/app/controllers/categories_controller.rb
@@ -54,7 +54,7 @@ class CategoriesController < ApplicationController
   # DELETE /decks/1
   # DELETE /decks/1.json
   def destroy
-    @category.destroy
+    @category.delete
     respond_to do |format|
       format.html { redirect_to categories_url, notice: 'Deck was successfully destroyed.' }
       format.json { head :no_content }

--- a/app/models/deck.rb
+++ b/app/models/deck.rb
@@ -1,5 +1,5 @@
 class Deck < ActiveRecord::Base
-  has_many :cards
+  has_many :cards, :dependent => :delete_all
   has_one :categories
   belongs_to :category
   validates_presence_of :title

--- a/db/migrate/20160209034316_change_fk_category.rb
+++ b/db/migrate/20160209034316_change_fk_category.rb
@@ -1,0 +1,6 @@
+class ChangeFkCategory < ActiveRecord::Migration
+  def change
+    remove_foreign_key :decks, :categories
+    add_foreign_key :decks, :categories, on_delete: :nullify
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160207230023) do
+ActiveRecord::Schema.define(version: 20160209034316) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -55,5 +55,5 @@ ActiveRecord::Schema.define(version: 20160207230023) do
   add_index "decks", ["category_id"], name: "index_decks_on_category_id", using: :btree
 
   add_foreign_key "cards", "decks"
-  add_foreign_key "decks", "categories"
+  add_foreign_key "decks", "categories", on_delete: :nullify
 end


### PR DESCRIPTION
Added a migration so that when you click the category delete button it cascades down to the decks correctly.
